### PR TITLE
supporting inline scenario definitions (test-params).

### DIFF
--- a/OneDrive.ApiDocumentation.Validation/CodeBlockAnnotation.cs
+++ b/OneDrive.ApiDocumentation.Validation/CodeBlockAnnotation.cs
@@ -100,6 +100,11 @@ namespace OneDrive.ApiDocumentation.Validation
         /// <summary>
         /// A simulated response, used for unit testing.
         /// </summary>
-        SimulatedResponse
+        SimulatedResponse,
+
+        /// <summary>
+        /// A block representing a test parameter definition for the preceding example
+        /// </summary>
+        TestParams,
     }
 }

--- a/OneDrive.ApiDocumentation.Validation/DocFile.cs
+++ b/OneDrive.ApiDocumentation.Validation/DocFile.cs
@@ -610,6 +610,12 @@ namespace OneDrive.ApiDocumentation.Validation
                         method.AddSimulatedResponse(code.Content, annotation);
                         return method;
                     }
+                case CodeBlockType.TestParams:
+                    {
+                        var method = m_Requests.Last();
+                        method.AddTestParams(code.Content);
+                        return method;
+                    }
                 default:
                     throw new NotSupportedException("Unsupported block type: " + annotation.BlockType);
             }

--- a/OneDrive.ApiDocumentation.Validation/MethodDefinition.cs
+++ b/OneDrive.ApiDocumentation.Validation/MethodDefinition.cs
@@ -27,6 +27,7 @@ namespace OneDrive.ApiDocumentation.Validation
             Errors = new List<ErrorDefinition>();
             Enumerations = new Dictionary<string, List<ParameterDefinition>>();
             RequestBodyParameters = new List<ParameterDefinition>();
+            Scenarios = new List<ScenarioDefinition>();
         }
 
         public static MethodDefinition FromRequest(string request, CodeBlockAnnotation annotation, DocFile source)
@@ -80,6 +81,10 @@ namespace OneDrive.ApiDocumentation.Validation
         /// <value>The actual response.</value>
         public string ActualResponse { get; set; }
 
+        /// <summary>
+        /// Scenarios defined inline with this method
+        /// </summary>
+        public List<ScenarioDefinition> Scenarios { get; private set; }
         #endregion
 
         public void AddExpectedResponse(string rawResponse, CodeBlockAnnotation annotation)
@@ -98,6 +103,17 @@ namespace OneDrive.ApiDocumentation.Validation
             ActualResponse = rawResponse;
         }
 
+        public void AddTestParams(string rawContent)
+        {
+            var scenarios = Newtonsoft.Json.JsonConvert.DeserializeObject<ScenarioDefinition[]>(rawContent);
+            if (null != scenarios)
+            {
+                foreach (var scenario in scenarios)
+                {
+                    Scenarios.Add(scenario);
+                }
+            }
+        }
 
         #region Validation / Request Methods
         ///// <summary>

--- a/OneDrive.ApiDocumentation.Validation/Scenarios.cs
+++ b/OneDrive.ApiDocumentation.Validation/Scenarios.cs
@@ -32,8 +32,12 @@ namespace OneDrive.ApiDocumentation.Validation
                         where p.MethodName == id
                         select p;
 
+            if (method.Scenarios != null && method.Scenarios.Count > 0)
+            {
+                query = query.Union(method.Scenarios);
+            }
+
             return query.ToArray();
         }
     }
-
 }


### PR DESCRIPTION
now you can follow request/response blocks with a 'testParams' block that contains the array of scenarios for the preceding example. anything found here is unioned with test scenarios found elsewhere. but creating separate scenarios is now optional.
