### PR TITLE
Support base-realtive links

### DIFF
--- a/ApiDocs.Validation/DocFile.cs
+++ b/ApiDocs.Validation/DocFile.cs
@@ -1028,6 +1028,13 @@ namespace ApiDocs.Validation
                 linkUrl = linkUrl.Substring(0, indexOfHash);
             }
 
+            if (linkUrl.StartsWith("/"))
+            {
+                // URL is relative to the base for the documentation
+                rootPath = docSetBasePath;
+                linkUrl = linkUrl.Substring(1);
+            }
+
             while (linkUrl.StartsWith(".." + Path.DirectorySeparatorChar))
             {
                 var nextLevelParent = new DirectoryInfo(rootPath).Parent;


### PR DESCRIPTION
Check-links currently says links that start with / are invalid relative URIs. This fixes this to allow these links to pass through check-links validation.