### PR TITLE
Add support for csharp code parameters

### DIFF
--- a/ApiDocs.Console/CommandLineOptions.cs
+++ b/ApiDocs.Console/CommandLineOptions.cs
@@ -177,7 +177,7 @@ namespace ApiDocs.ConsoleApp
         [Option('m', "method", HelpText = "Name of the method to test. If omitted, all defined methods are tested.", MutuallyExclusiveSet="fileOrMethod")]
         public string MethodName { get; set; }
 
-        [Option("file", HelpText="Name of the doc file to test. If missing, all methods are tested.", MutuallyExclusiveSet="fileOrMethod")]
+        [Option("file", HelpText="Name of the files to test. Wildcard(*) is allowed. If missing, all methods are tested.", MutuallyExclusiveSet="fileOrMethod")]
         public string FileName { get; set; }
 
         [Option("force-all", HelpText="Force all defined scenarios to be executed, even if disabled.")]

--- a/ApiDocs.Console/Program.cs
+++ b/ApiDocs.Console/Program.cs
@@ -602,20 +602,42 @@ namespace ApiDocs.ConsoleApp
             }
             else if (!string.IsNullOrEmpty(options.FileName))
             {
-                var selectedFileQuery = from f in docset.Files where f.DisplayName == options.FileName select f;
-                var selectedFile = selectedFileQuery.SingleOrDefault();
-                if (selectedFile == null)
+                var selectedFileQuery = FilesMatchingFilter(docset, options.FileName);
+                if (!selectedFileQuery.Any())
                 {
-                    FancyConsole.WriteLine(FancyConsole.ConsoleErrorColor, "Unable to locate file '{0}' in docset.", options.FileName);
+                    FancyConsole.WriteLine(FancyConsole.ConsoleErrorColor, "Unable to locate file matching '{0}' in docset.", options.FileName);
                     Exit(failure: true);
                 }
-                methods = selectedFile.Requests;
+
+                List<MethodDefinition> foundMethods = new List<MethodDefinition>();
+                foreach (var docFile in selectedFileQuery)
+                {
+                    foundMethods.AddRange(docFile.Requests);
+                }
+                methods = foundMethods.ToArray();
             }
             else
             {
                 methods = docset.Methods;
             }
             return methods;
+        }
+
+        private static IEnumerable<DocFile> FilesMatchingFilter(DocSet docset, string filter)
+        {
+            if (filter.EndsWith("*"))
+            {
+                return from f in docset.Files
+                       where f.DisplayName.StartsWith(filter.TrimEnd('*'))
+                       select f;
+
+            }
+            else
+            {
+                return from f in docset.Files
+                       where f.DisplayName == filter
+                       select f;
+            }
         }
 
 

--- a/ApiDocs.Validation/ApiDocs.Validation.csproj
+++ b/ApiDocs.Validation/ApiDocs.Validation.csproj
@@ -79,6 +79,7 @@
     <Compile Include="PageAnnotation.cs" />
     <Compile Include="ParameterDataType.cs" />
     <Compile Include="ParameterDefinition.cs" />
+    <Compile Include="Params\CSharpEval.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/ApiDocs.Validation/Params/BasicRequestDefinition.cs
+++ b/ApiDocs.Validation/Params/BasicRequestDefinition.cs
@@ -128,6 +128,8 @@ namespace ApiDocs.Validation.Params
             }
             if (key.StartsWith("$"))
                 return PlaceholderLocation.Json;
+            if (key.StartsWith("#"))
+                return PlaceholderLocation.CSharpCode;
 
             return PlaceholderLocation.Invalid;
         }

--- a/ApiDocs.Validation/Params/CSharpEval.cs
+++ b/ApiDocs.Validation/Params/CSharpEval.cs
@@ -1,0 +1,106 @@
+﻿/*
+ * Markdown Scanner
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved. 
+ * 
+ * MIT License
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the ""Software""), to deal in 
+ * the Software without restriction, including without limitation the rights to use, 
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace ApiDocs.Validation.Params
+{
+    using System;
+    using System.Text;
+    using System.Reflection;
+    using Microsoft.CSharp;
+    using System.CodeDom.Compiler;
+
+    internal static class CSharpEval
+    {
+        public static string Evaluate(string code)
+        {
+            if (!code.EndsWith(";"))
+            {
+                code += ";";
+            }
+
+            string codeWrapper = 
+            "namespace MarkdownScanner.Eval { " +
+                "using System; " +
+                "public class MethodEval {" +
+                    "public static object RunCode() {" +
+                        "return " + code +
+                    "}" +
+                "}" +
+            "}";
+
+            Assembly asm = GenerateAssembly(codeWrapper);
+            
+            Module mod = asm.GetModules()[0];
+            if (null == mod)
+            {
+                throw new Exception("Unable to locate dynamic code module.");
+            }
+
+            Type t = mod.GetType("MarkdownScanner.Eval.MethodEval");
+            if (null == t)
+            {
+                throw new Exception("Unable to locate MethodEval type");
+            }
+                
+            var methodInfo = t.GetMethod("RunCode");
+            object result = methodInfo.Invoke(null, new object[0]);
+
+            if (result is DateTimeOffset)
+            {
+                return ((DateTimeOffset)result).ToUniversalTime().ToString(@"yyyy-MM-ddTHH\:mm\:ssZ");
+            }
+            else
+            {
+                return result.ToString();
+            }
+        }
+
+        private static Assembly GenerateAssembly(string code)
+        {
+            CSharpCodeProvider provider = new CSharpCodeProvider();
+            CompilerParameters compilerparams = new CompilerParameters();
+            compilerparams.GenerateExecutable = false;
+            compilerparams.GenerateInMemory = true;
+
+            var results =
+               provider.CompileAssemblyFromSource(compilerparams, code);
+
+            if (results.Errors.HasErrors)
+            {
+                StringBuilder errors = new StringBuilder("Compiler Errors :\r\n");
+                foreach (CompilerError error in results.Errors)
+                {
+                    errors.AppendFormat("Line {0},{1}\t: {2}\n",
+                           error.Line, error.Column, error.ErrorText);
+                }
+                throw new Exception(errors.ToString());
+            }
+            else
+            {
+                return results.CompiledAssembly;
+            }
+        }
+    }
+}

--- a/ApiDocs.Validation/Params/RequestDefinitionExtensions.cs
+++ b/ApiDocs.Validation/Params/RequestDefinitionExtensions.cs
@@ -170,6 +170,11 @@ namespace ApiDocs.Validation.Params
                         : value
             };
 
+            if (BasicRequestDefinition.LocationForKey(v.Value) == PlaceholderLocation.CSharpCode)
+            {
+                v.Value = CSharpEval.Evaluate(v.Value.Substring(1));
+            }
+
             // Allow the random-filename generator to swap the value with a randomly generated filename.
             int index = value == null ? -1 : value.IndexOf(RandomFilenameValuePrefix);
             if (index >= 0)

--- a/ApiDocs.Validation/Params/ScenarioDefinition.cs
+++ b/ApiDocs.Validation/Params/ScenarioDefinition.cs
@@ -79,6 +79,7 @@ namespace ApiDocs.Validation.Params
         HttpHeader,
         Body,
         StoredValue,
-        BodyBase64Encoded
+        BodyBase64Encoded,
+        CSharpCode
     }
 }


### PR DESCRIPTION
I may have gone too far.

This commit also allows you to do wildcard matching for --file input, so you can scan a whole directory of files without doing everything else.