### PR TITLE
Add command line publishing flag to enable unsafe HTML passthrough

### DIFF
--- a/ApiDocs.Console/CommandLineOptions.cs
+++ b/ApiDocs.Console/CommandLineOptions.cs
@@ -369,6 +369,9 @@ namespace ApiDocs.ConsoleApp
         [Option("parameters", HelpText="Specify additional page variables that are used by the publishing engine. URL encoded: key=value&key2=value2.")]
         public string AdditionalPageParameters { get; set; }
 
+        [Option("allow-unsafe-html", HelpText="Allows HTML tags in the markdown source to be passed through to the output markdown.")]
+        public bool AllowUnsafeHtmlContentInMarkdown { get; set; }
+
         #region Swagger2 output controls
 
         [Option("swagger-title", DefaultValue=null, HelpText="Title to include in the published documentation")]

--- a/ApiDocs.Publishing/Html/DocumentPublisherHtml.cs
+++ b/ApiDocs.Publishing/Html/DocumentPublisherHtml.cs
@@ -44,11 +44,18 @@ namespace ApiDocs.Publishing.Html
         public string HtmlOutputExtension { get; set; }
         public string TemplateHtmlFilename { get; set; }
 
+        /// <summary>
+        /// Allow HTML tags in the markdown source to pass through to the converted HTML. This is considered
+        /// unsafe.
+        /// </summary>
+        public bool EnableHtmlTagPassThrough { get; set; }
+
         public DocumentPublisherHtml(DocSet docs, IPublishOptions options) 
             : base(docs, options)
         {
             TemplateHtmlFilename =  options.TemplateFilename ?? "template.htm";
             HtmlOutputExtension = options.OutputExtension ?? ".htm";
+            EnableHtmlTagPassThrough = options.AllowUnsafeHtmlContentInMarkdown;
         }
 
         /// <summary>
@@ -182,7 +189,7 @@ namespace ApiDocs.Publishing.Html
             {
                 ExtraMode = true,
                 NewWindowForExternalLinks = true,
-                SafeMode = true,
+                SafeMode = this.EnableHtmlTagPassThrough,
                 AutoHeadingIDs = true,
                 QualifyUrl = this.QualifyUrl
             };

--- a/ApiDocs.Validation/Writers/IPublishOptions.cs
+++ b/ApiDocs.Validation/Writers/IPublishOptions.cs
@@ -67,10 +67,12 @@ namespace ApiDocs.Validation.Writers
         /// <summary>
         /// Specify that a table of contents file should be written in the relative path provided.
         /// </summary>
-        string TableOfContentsOutputRelativePath
-        {
-            get; set;
-        }
+        string TableOfContentsOutputRelativePath { get; set; }
+
+        /// <summary>
+        /// Allows HTML tags in the markdown source to be passed through to the output markdown.
+        /// </summary>
+        bool AllowUnsafeHtmlContentInMarkdown { get; set; }
     }
 
     public class DefaultPublishOptions : IPublishOptions
@@ -86,5 +88,7 @@ namespace ApiDocs.Validation.Writers
         public string AdditionalPageParameters { get; set; }
 
         public string TableOfContentsOutputRelativePath { get; set; }
+
+        public bool AllowUnsafeHtmlContentInMarkdown { get; set; }
     }
 }


### PR DESCRIPTION
Adds a command line flag `--allow-unsafe-html` when using the publishing action to allow HTML tags in the source markdown documents to be passed through without being HTML encoded. This allows safe and unsafe HTML tag usage in the markdown file to be output into the HTML data.