### PR TITLE
Fix issue with canned-request capture stacking

### DIFF
--- a/ApiDocs.Validation/Params/ScenarioDefinition.cs
+++ b/ApiDocs.Validation/Params/ScenarioDefinition.cs
@@ -80,6 +80,16 @@ namespace ApiDocs.Validation.Params
 
         [JsonProperty("implicit-variable")]
         public string ImplicitVariable { get; set; }
+
+        /// <summary>
+        /// Copy all the paramters of this to a new instance so modifications to canned requests don't stack on each other
+        /// </summary>
+        /// <returns></returns>
+        public CannedRequestDefinition CopyInstance()
+        {
+            string data = Newtonsoft.Json.JsonConvert.SerializeObject(this);
+            return Newtonsoft.Json.JsonConvert.DeserializeObject<CannedRequestDefinition>(data);
+        }
     }
 
     public enum PlaceholderLocation

--- a/ApiDocs.Validation/Params/TestSetupRequestDefinition.cs
+++ b/ApiDocs.Validation/Params/TestSetupRequestDefinition.cs
@@ -101,7 +101,10 @@ namespace ApiDocs.Validation.Params
                     return new ValidationResult<bool>(false, errors);
                 }
 
-                return await cannedRequest.MakeSetupRequestAsync(baseUrl, credentials, storedValues, documents, scenario, this.OutputValues);
+
+                // Need to make a copy of the canned request here so that our state doesn't continue to pile up
+                var cannedRequestInstance = cannedRequest.CopyInstance();
+                return await cannedRequestInstance.MakeSetupRequestAsync(baseUrl, credentials, storedValues, documents, scenario, this.OutputValues);
             }
             
             // Get the HttpRequest, either from MethodName or by parsing HttpRequest


### PR DESCRIPTION
When adding additional capture variables to a canned request, the capture set was added to the single instance canned request object. Thus, each time capture variables were added to a canned request, all future uses of that canned request also captured that variable. This made it impossible to use the same canned request multiple times to store values for a test request, since the final canned request overwrote all the previously captured variables.

The fix was to create a 1-off instance for the canned request object each time we use it, so that anything added to that canned request doesn't affect other requests.