### PR TITLE
Fix issue with parameters being lower-cased in all cases.

### DIFF
--- a/ApiDocs.Console/CommandLineOptions.cs
+++ b/ApiDocs.Console/CommandLineOptions.cs
@@ -106,7 +106,7 @@ namespace ApiDocs.ConsoleApp
 
                 var data = new Dictionary<string, object>();
 
-                var parameters = Validation.Http.HttpParser.ParseQueryString(AdditionalPageParameters.ToLower());
+                var parameters = Validation.Http.HttpParser.ParseQueryString(AdditionalPageParameters);
                 foreach (var key in parameters.AllKeys)
                 {
                     data[key] = parameters[key];

--- a/ApiDocs.Console/Program.cs
+++ b/ApiDocs.Console/Program.cs
@@ -41,6 +41,7 @@ namespace ApiDocs.ConsoleApp
     using ApiDocs.Validation.OData;
     using ApiDocs.Validation.Params;
     using ApiDocs.Validation.Writers;
+    using ApiDocs.Validation.Tags;
     using CommandLine;
     using Newtonsoft.Json;
     
@@ -231,13 +232,7 @@ namespace ApiDocs.ConsoleApp
             FancyConsole.VerboseWriteLine("Scanning documentation files...");
             ValidationError[] loadErrors;
 
-            string tagsToInclude = string.Empty;
-            if (options.PageParameterDict != null &&
-                options.PageParameterDict.ContainsKey("tags"))
-            {
-                tagsToInclude = options.PageParameterDict["tags"]?.ToString();
-            }
-
+            string tagsToInclude =  options.PageParameterDict.ValueForKey<string>("tags", StringComparison.OrdinalIgnoreCase) ?? string.Empty;
             if (!set.ScanDocumentation(tagsToInclude, out loadErrors))
             {
                 FancyConsole.WriteLine("Errors detected while parsing documentation set:");

--- a/ApiDocs.Publishing/Html/DocumentPublisherHtml.cs
+++ b/ApiDocs.Publishing/Html/DocumentPublisherHtml.cs
@@ -231,7 +231,9 @@ namespace ApiDocs.Publishing.Html
             var destinationPath = this.GetPublishedFilePath(sourceFile, destinationRoot, HtmlOutputExtension);
 
             // Create a tag processor
-            TagProcessor tagProcessor = new TagProcessor(PageParameters?["tags"]?.ToString(),
+            string tagsInput = PageParameters.ValueForKey<string>("tags", StringComparison.OrdinalIgnoreCase) ?? string.Empty;
+
+            TagProcessor tagProcessor = new TagProcessor(tagsInput,
                 page.Parent.SourceFolderPath, LogMessage);
 
             var converter = this.GetMarkdownConverter();

--- a/ApiDocs.Validation/Tags/TagProcessor.cs
+++ b/ApiDocs.Validation/Tags/TagProcessor.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using ApiDocs.Validation.Error;
 using System.Text.RegularExpressions;
 using MarkdownDeep;
+using System.Collections.Generic;
 
 namespace ApiDocs.Validation.Tags
 {
@@ -369,5 +370,39 @@ namespace ApiDocs.Validation.Tags
         {
             // Empty method
         }
+    }
+
+    public static class TagProcessorExtensions
+    {
+        public static T ValueForKey<T>(this Dictionary<string, object> source, string key, StringComparison comparison)
+        {
+            object value;
+            if (source.TryGetValueForKey(key, comparison, out value))
+                return (T)value;
+
+            return default(T);
+        }
+
+        public static bool TryGetValueForKey<T>(this Dictionary<string, object> source, string key, StringComparison comparison, out T value)
+        {
+            if (source != null)
+            {
+                string keyName = source.Keys.Where(x => x.Equals(key, comparison)).FirstOrDefault();
+                if (null != keyName)
+                {
+                    value = (T)source[keyName];
+                    return true;
+                }
+            }
+
+            value = default(T);
+            return false;
+        }
+
+        public static bool TryGetValueForKey(this Dictionary<string, object> source, string key, StringComparison comparison, out object value)
+        {
+            return source.TryGetValueForKey<object>(key, comparison, out value);
+        }
+            
     }
 }


### PR DESCRIPTION
To make sure "tags" worked in all cases, the whole page parameters string was pushed to lower case. This breaks other scenarios, like injection into publishing templates, which expects the parameters to be case sensitive. This pull request enables "tags" in any case without breaking other scenarios.