### PR TITLE
Fix crash in check-all command

### DIFF
--- a/ApiDocs.Console/Auth/BasicAccount.cs
+++ b/ApiDocs.Console/Auth/BasicAccount.cs
@@ -53,5 +53,10 @@ namespace ApiDocs.ConsoleApp.Auth
         {
             return new BasicCredentials { Username = this.Username, Password = this.Password };
         }
+
+        public void OverrideBaseUrl(string newBaseUrl)
+        {
+            this.BaseUrl = newBaseUrl;
+        }
     }
 }

--- a/ApiDocs.Console/Auth/OAuthAccount.cs
+++ b/ApiDocs.Console/Auth/OAuthAccount.cs
@@ -216,6 +216,11 @@ namespace ApiDocs.ConsoleApp.Auth
         {
             return OAuthCredentials.CreateAutoCredentials(this.AccessToken);
         }
+
+        public void OverrideBaseUrl(string newBaseUrl)
+        {
+            this.BaseUrl = newBaseUrl;
+        }
     }
 
     public enum OAuthAccountType

--- a/ApiDocs.Console/CommandLineOptions.cs
+++ b/ApiDocs.Console/CommandLineOptions.cs
@@ -60,7 +60,7 @@ namespace ApiDocs.ConsoleApp
         public BasicCheckOptions CheckDocsVerb { get; set; }
 
         [VerbOption(VerbCheckAll, HelpText = "Check for errors in the documentation (links + resources + examples)")]
-        public BasicCheckOptions CheckAllVerbs { get; set; }
+        public CheckLinkOptions CheckAllVerbs { get; set; }
 
         [VerbOption(VerbService, HelpText = "Check for errors between the documentation and service.")]
         public CheckServiceOptions CheckServiceVerb { get; set; }

--- a/ApiDocs.Console/Program.cs
+++ b/ApiDocs.Console/Program.cs
@@ -982,6 +982,12 @@ namespace ApiDocs.ConsoleApp
             Dictionary<string, CheckResults> results = new Dictionary<string, CheckResults>();
             foreach (var account in accountsToProcess)
             {
+                // if the service root URL is also provided, override the account URL
+                if (!string.IsNullOrEmpty(options.ServiceRootUrl))
+                {
+                    account.OverrideBaseUrl(options.ServiceRootUrl);
+                }
+
                 var accountResults = await CheckMethodsForAccountAsync(options, account, methods, docset);
                 if (null != accountResults)
                 {

--- a/ApiDocs.Validation/IServiceAccount.cs
+++ b/ApiDocs.Validation/IServiceAccount.cs
@@ -72,5 +72,11 @@ namespace ApiDocs.Validation
         /// </summary>
         /// <returns></returns>
         AuthenicationCredentials CreateCredentials();
+
+        /// <summary>
+        /// Allow the base url to be overridden if passed in from another source
+        /// </summary>
+        /// <param name="newBaseUrl"></param>
+        void OverrideBaseUrl(string newBaseUrl);
     }
 }


### PR DESCRIPTION
Also enables the ability to override the URL for check-service when using an account (using for testing pre-production versions of an API endpoint).