### PR TITLE
Fix publish-edmx when --skip-generation is set

### DIFF
--- a/ApiDocs.Publishing/CSDL/CsdlWriter.cs
+++ b/ApiDocs.Publishing/CSDL/CsdlWriter.cs
@@ -205,7 +205,7 @@ namespace ApiDocs.Publishing.CSDL
             bool generateNewElements = (generateFromDocs == null && !options.SkipMetadataGeneration) || (generateFromDocs.HasValue && generateFromDocs.Value) ;
 
             // Add resources
-            if (generateNewElements && Documents.Files.Any())
+            if (Documents.Files.Any())
             {
                 foreach (var resource in Documents.Resources)
                 {


### PR DESCRIPTION
[fff2ec8](https://github.com/OneDrive/markdown-scanner/commit/fff2ec86b07a2757004407ad1dddbef6bd8dd11e) broke the scenario when running the console tool using the settings `"publish-edmx --skip-generation"`. Running the tool after this change results in no annotations being added from the docs to the metadata file. This includes LongDescription annotations on all available properties in the metadata.

As far as I can tell, the bug was introduced due to an overly-inclusive if-statement. The `generateNewElements` Boolean is used in both the previous and current versions of the code to pass through to other helper methods in the `CsdlWriter`, specifically `FindOrCreateSchemaForNamespace` and `AddResourceToSchema`. Previously, the `BuildEntityContainer` and `ProcessRequestPaths` methods were run regardless of whether `generateNewElements` was set. I believe we want to preserve this behavior.