### PR TITLE
changed markdowndeep submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "OSS/markdowndeep"]
 	path = OSS/markdowndeep
-	url = https://github.com/rgregg/markdowndeep.git
+	url = https://github.com/OneDrive/markdowndeep.git

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,10 @@ perform for the following validations:
 
 ## Building
 To build the project, invoke either `msbuild` or `xbuild` depending on your
-platform. This tool is compatible with Mono or .NET.
+platform. This tool is compatible with Mono or .NET. 
+
+Note: After cloning and prior to the first build, make sure to run the two commands 
+`git submodule init` and `git submodule update` to fetch all the data from the markdowndeep submodule.
 
 ## Command Line Tool
 


### PR DESCRIPTION
Markdowndeep now references OneDrive's forked repo. Issue #162 